### PR TITLE
upload: introduce file upload command

### DIFF
--- a/cap_client/cli/__init__.py
+++ b/cap_client/cli/__init__.py
@@ -31,7 +31,8 @@ import os
 import sys
 
 from cap_client.cap_api import CapAPI
-from cap_client.cli.cli import create, delete, get, ping, types, update, patch
+from cap_client.cli.cli import (create, delete, get, ping,
+                                types, update, patch, upload)
 
 
 class Config(object):
@@ -39,12 +40,12 @@ class Config(object):
 
     def __init__(self, access_token=None, verbose=False):
         """Initialize config variables."""
-        server = os.environ.get(
+        self.server = os.environ.get(
             'CAP_SERVER_URL', 'https://analysispreservation.cern.ch')
         apipath = os.environ.get('CAP_SERVER_API_PATH', 'api')
         access_token = access_token or os.environ.get('CAP_ACCESS_TOKEN', None)
 
-        self.cap_api = CapAPI(server, apipath, access_token)
+        self.cap_api = CapAPI(self.server, apipath, access_token)
         self.verbose = verbose
 
 
@@ -76,3 +77,4 @@ cli.add_command(delete)
 cli.add_command(update)
 cli.add_command(patch)
 cli.add_command(types)
+cli.add_command(upload)

--- a/cap_client/cli/cli.py
+++ b/cap_client/cli/cli.py
@@ -149,6 +149,40 @@ def update(ctx, pid, file):
 @click.option(
     '--pid',
     '-p',
+    help='Upload file to deposit with given pid',
+    default=None,
+    required=True
+)
+@click.argument('file', type=click.Path(exists=True))
+@click.option(
+    '--output-file',
+    '-o',
+    help='Filename to be given to uploaded file',
+    default=None,
+)
+@click.option(
+    '--yes',
+    is_flag=True,
+    help="Bypasses prompts..Say YES to everything"
+)
+@click.pass_context
+def upload(ctx, pid, file, yes, output_file=None):
+    """Update analysis with given pid."""
+    try:
+        response = ctx.obj.cap_api.upload(
+            pid=pid, filepath=file, output_filename=output_file, yes=yes)
+        logging.info('Server response:\n{}'.format(
+            json.dumps(response, indent=4)))
+
+    except Exception as e:
+        logging.info('Unexpected error.')
+        logging.debug(str(e))
+
+
+@click.command()
+@click.option(
+    '--pid',
+    '-p',
     help='Patch deposit with given pid',
     default=None,
     required=True

--- a/cap_client/utils.py
+++ b/cap_client/utils.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Analysis Preservation Framework.
+# Copyright (C) 2016, 2017 CERN.
+#
+# CERN Analysis Preservation Framework is free software; you can redistribute
+# it and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Analysis Preservation Framework is distributed in the hope that it will
+# be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Analysis Preservation Framework; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+"""CAP Client Utils."""
+import tarfile
+import os
+
+
+def make_tarfile(output_filename, source_dir):
+    """Makes a tarball out of {source_dir} into {output_filename}"""
+    with tarfile.open(output_filename, "w:gz") as tar:
+        tar.add(source_dir, arcname=os.path.basename(source_dir))

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,7 @@ setup_requires = [
 
 install_requires = [
     'click>=6.7',
+    'requests>=2.18.4',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* gets file or directory and uploads it to provided pid

```
# Make Tarfile of current DIR and upload 
cap-client upload -p <pid_value> <directory>
# Make Tarfile of current DIR and upload WITHOUT prompts
cap-client upload -p <pid_value> <directory> --yes
# Make Tarfile of current DIR and upload with name "currentDir.tar.gz"
cap-client upload -p <pid_value> <directory> -o <filename_when_uploaded>
# Upload <file> and rename to <filename_when_uploaded> when uploaded
cap-client upload -p <pid_value> <file> -o <filename_when_uploaded>
# Upload <file>
cap-client upload -p <pid_value> <file> 

```