### PR TITLE
cli: fix parameters of get/get_shared commands

### DIFF
--- a/cap_client/cap_api.py
+++ b/cap_client/cap_api.py
@@ -135,24 +135,25 @@ class CapAPI(object):
 
     def get(self, pid=None, all=False):
         """Retrieve one or all analyses from a user."""
-        if pid or all:
-            url = urljoin('deposits/', pid)
-        else:
-            user_id = self.me().get('id', '')
-            url = urljoin('deposits/', '?q=_deposit.created_by:{}'.format(
-                user_id))
+        url = urljoin('deposits/', pid) if pid or all \
+            else 'deposits/?q=&by_me=True'
 
-        response = self._make_request(url=url, headers={
-            'Accept': 'application/basic+json'})
+        response = self._make_request(url=url,
+                                      headers={
+                                          'Accept': 'application/basic+json'
+                                      })
 
         return response if pid else response['hits']['hits']
 
-    def get_shared(self, pid=None):
+    def get_shared(self, pid=None, all=False):
         """Retrieve one or all shared analyses from a user."""
-        response = self._make_request(url=urljoin('records/', pid),
+        url = urljoin('records/', pid) if pid or all \
+            else 'records/?q=&by_me=True'
+
+        response = self._make_request(url=url,
                                       headers={
                                           'Accept': 'application/basic+json'
-        })
+                                      })
 
         return response if pid else response['hits']['hits']
 

--- a/cap_client/cli/cli.py
+++ b/cap_client/cli/cli.py
@@ -75,13 +75,14 @@ def me(ctx):
 @click.option(
     '--all',
     is_flag=True,
+    default=False,
     help="Retrieve all shared analyses you can access."
 )
 @click.pass_context
 def get_shared(ctx, pid, all):
     """Retrieve one or all shared analyses from a user."""
     try:
-        response = ctx.obj.cap_api.get_shared(pid=pid)
+        response = ctx.obj.cap_api.get_shared(pid=pid, all=all)
         click.echo(json.dumps(response,
                               indent=4))
 


### PR DESCRIPTION
* uses by_me in queries instead of user id
* adds 'all' parameter for get_shared
* closes #103
* closes #104 

Signed-off-by: Ilias Koutsakis <ilias.koutsakis@cern.ch>